### PR TITLE
NEDS-71-72-75

### DIFF
--- a/doc/harmony-ap_installation_guide.md
+++ b/doc/harmony-ap_installation_guide.md
@@ -1,6 +1,6 @@
 # Harmony eDelivery Access - Access Point Installation Guide <!-- omit in toc -->
 
-Version: 1.1  
+Version: 1.2  
 Doc. ID: IG-AP
 
 ---
@@ -11,6 +11,7 @@ Doc. ID: IG-AP
  ---------- | ------- | ------------------------------------------------------------------------| --------------------
  15.11.2021 | 1.0     | Initial version                                                         |
  07.01.2022 | 1.1     | Add reference to the Static Discovery Configuration Guide \[UG-SDCG\]   | Petteri Kivimäki
+ 08.01.2022 | 1.2     | Add TLS truststore to section [2.10](#210-location-of-configuration-and-generated-passwords) | Petteri Kivimäki
  
 ## License <!-- omit in toc -->
 
@@ -157,7 +158,7 @@ Upon the first installation of the Access Point, the system asks for the followi
   - the value can be edited later by changing the `domibus.smlzone` property in the `/etc/harmony-ap/domibus.properties` configuration file;
 - username of the administrative user - username to use to log in to administrative UI;
 - initial password for the administrative user;
-- `Distinguished Name` for generated self signed content and transport certificates;
+- `Distinguished Name` for generated self-signed content encryption and TLS certificates;
   - For example: `CN=example.com, O=My Organisation, C=FI`;
   - *Note:* different eDelivery policy domains may have different requirements for the `Distinguished Name`. If you're not sure about the requirements, please contact the domain authority of the policy domain where the Access Point is registered.
 
@@ -220,5 +221,6 @@ During the installation process, multiple random passwords are generated.
 |---|---|
 | Password for `harmony-ap` MySQL user | Configuration file: `/etc/harmony-ap/domibus.properties`<br /><br />Properties: `domibus.datasource.xa.property.password` and `domibus.datasource.password`. |
 | Content encryption keystore (`/etc/harmony-ap/ap-keystore.jks`) password | Configuration file: `/etc/harmony-ap/domibus.properties`<br /><br />Properties: `domibus.security.keystore.password` and `domibus.security.key.private.password`. Content of this keystore can be changed using the administrative UI. |
-| Content encryption truststore (`/etc/harmony-ap/ap-truststore.jks`) password | `Configuration file: /etc/harmony-ap/domibus.properties`<br /><br />Properties: `domibus.security.truststore.password`. Content of this keystore can be changed using UI. |
-| TLS keystore (`/etc/harmony-ap/tls-keystore.jks`) password | Configuration file: `/etc/harmony-ap/conf/server.xml` |
+| Content encryption truststore (`/etc/harmony-ap/ap-truststore.jks`) password | Configuration file: `/etc/harmony-ap/domibus.properties`<br /><br />Properties: `domibus.security.truststore.password`. Content of this keystore can be changed using the administrative UI. |
+| TLS keystore (`/etc/harmony-ap/tls-keystore.jks`) password | Configuration file: `/etc/harmony-ap/conf/server.xml`<br /><br />Property: `keystorePass` |
+| TLS truststore (`/etc/harmony-ap/tls-truststore.jks`) password | Configuration file: `/etc/harmony-ap/conf/server.xml`<br /><br />Property: `truststorePass` |

--- a/doc/harmony-ap_installation_guide.md
+++ b/doc/harmony-ap_installation_guide.md
@@ -11,7 +11,7 @@ Doc. ID: IG-AP
  ---------- | ------- | ------------------------------------------------------------------------| --------------------
  15.11.2021 | 1.0     | Initial version                                                         |
  07.01.2022 | 1.1     | Add reference to the Static Discovery Configuration Guide \[UG-SDCG\]   | Petteri Kivimäki
- 08.01.2022 | 1.2     | Add TLS truststore to section [2.10](#210-location-of-configuration-and-generated-passwords) | Petteri Kivimäki
+ 08.01.2022 | 1.2     | Add party name to section [2.5](#25-access-point-installation) and TLS truststore to section [2.10](#210-location-of-configuration-and-generated-passwords) | Petteri Kivimäki
  
 ## License <!-- omit in toc -->
 
@@ -158,9 +158,11 @@ Upon the first installation of the Access Point, the system asks for the followi
   - the value can be edited later by changing the `domibus.smlzone` property in the `/etc/harmony-ap/domibus.properties` configuration file;
 - username of the administrative user - username to use to log in to administrative UI;
 - initial password for the administrative user;
+- party name of the Access Point owner organisation;
+  - if you don't know the party name of the owner, use the default value (`selfsigned`);
 - `Distinguished Name` for generated self-signed content encryption and TLS certificates;
-  - For example: `CN=example.com, O=My Organisation, C=FI`;
-  - *Note:* different eDelivery policy domains may have different requirements for the `Distinguished Name`. If you're not sure about the requirements, please contact the domain authority of the policy domain where the Access Point is registered.
+  - for example: `CN=example.com, O=My Organisation, C=FI`;
+  - *note:* different eDelivery policy domains may have different requirements for the `Distinguished Name`. If you're not sure about the requirements, please contact the domain authority of the policy domain where the Access Point is registered.
 
 See the Static Discovery Configuration Guide \[[UG-SDCG](static_discovery_configuration_guide.md)\] and the Dynamic Discovery Configuration Guide \[[UG-DDCG](dynamic_discovery_configuration_guide.md)\] for more information about how to configure different discovery options.
 

--- a/doc/harmony-ap_installation_guide.md
+++ b/doc/harmony-ap_installation_guide.md
@@ -208,7 +208,7 @@ In addition to installing required dependencies, the installation process comple
 - creates MySQL database user `harmony_ap` and generates random password for it;
 - creates MySQL database schema `harmony_ap` and populates it with needed metadata;
 - loads initial configuration into database;
-- generates self-signed certificates for content encryption and for transport encryption;
+- generates self-signed certificates for content encryption and transport encryption;
 - configures One-Way SSL between two Access Points;
 - installs the `harmony-ap` systemd service but does not enable or start it.
 

--- a/doc/harmony-ap_installation_guide.md
+++ b/doc/harmony-ap_installation_guide.md
@@ -211,7 +211,8 @@ In addition to installing required dependencies, the installation process comple
 - creates MySQL database schema `harmony_ap` and populates it with needed metadata;
 - loads initial configuration into database;
 - generates self-signed certificates for content encryption and transport encryption;
-- configures One-Way SSL between two Access Points;
+- creates initial configuration for One-Way SSL between two Access Points;
+  - sharing and importing certificates must be handled manually after the installation;
 - installs the `harmony-ap` systemd service but does not enable or start it.
 
 ### 2.10 Location of Configuration and Generated Passwords 

--- a/doc/harmony-ap_installation_guide.md
+++ b/doc/harmony-ap_installation_guide.md
@@ -209,6 +209,7 @@ In addition to installing required dependencies, the installation process comple
 - creates MySQL database schema `harmony_ap` and populates it with needed metadata;
 - loads initial configuration into database;
 - generates self-signed certificates for content encryption and for transport encryption;
+- configures One-Way SSL between two Access Points;
 - installs the `harmony-ap` systemd service but does not enable or start it.
 
 ### 2.10 Location of Configuration and Generated Passwords 

--- a/doc/static_discovery_configuration_guide.md
+++ b/doc/static_discovery_configuration_guide.md
@@ -301,8 +301,9 @@ the policy domain where the Access Point is registered.
 
 The TLS certificate truststore located in `/etc/harmony-ap/tls-truststore.jks` can not be updated through the admin UI.
 By default, the TLS truststore contains one trusted TLS certificate which is the Access Point's own public TLS certificate.
-The alias of the Access Point's own TLS certificate is `selfsigned`. If the same Access Point acts as a sender and 
-receiver, it must trust its own TLS certificate.
+The alias of the Access Point's own TLS certificate is the party name of the Access Point owner. If the party name of the 
+owner wasn't defined during the installation process, the default value is `selfsigned`. If the same Access Point acts 
+as a sender and receiver, it must trust its own TLS certificate.
 
 If the certificate to be imported is a TLS certificate of a data exchange party, it's recommended to use the party name 
 of the other party as an alias for the certificate. Instead, if the certificate to be imported is a root certificate 

--- a/doc/static_discovery_configuration_guide.md
+++ b/doc/static_discovery_configuration_guide.md
@@ -171,10 +171,9 @@ on the configuration that's used.
 
 **Note:** In the `/etc/harmony-ap/clientauthentication.xml` configuration examples, the `disableCNCheck` attribute specifies 
 whether it is checked if the host name specified in the URL matches the host name specified in the Common Name (CN) of
-the server's certificate. In the examples the value is `true` which means that the check is disabled and self-signed
-certificates can be used. However, in production environment the value should be set to `false` which means that the
-check is enabled and self-signed certificates can not be used. Also, in the default configuration the value of the 
-`disableCNCheck` attribute  is `false`.
+the server's certificate. In the examples the value is `true` which means that the check is disabled. However, in 
+production environment the value should be set to `false`. In the default configuration the value of the `disableCNCheck` 
+attribute is `false`.
 
 #### 2.3.1 One-Way SSL
 
@@ -182,9 +181,9 @@ When One-Way SSL is used (default), the sender validates the signature of the re
 the receiver. The public certificate of the receiver is expected to be present in the `/etc/harmony-ap/tls-truststore.jks` 
 file. 
 
-In the default configuration the value of the `disableCNCheck` attribute is `false` which means that self-signed certificates
-can not be used. However, if self-signed certificates are used, the value of the `disableCNCheck` attribute must be set to `true`.
-In that case, the `/etc/harmony-ap/clientauthentication.xml` file should look like this:
+In the default configuration the value of the `disableCNCheck` attribute is `false`. However, if self-signed certificates 
+are used, the value of the `disableCNCheck` attribute might need to be set to `true`. In that case, the 
+`/etc/harmony-ap/clientauthentication.xml` file should look like this:
 
 ```xml
 <http-conf:tlsClientParameters disableCNCheck="true" secureSocketProtocol="TLSv1.2"

--- a/doc/static_discovery_configuration_guide.md
+++ b/doc/static_discovery_configuration_guide.md
@@ -538,7 +538,7 @@ The sign certificate of the Access Point 2 (`org2_gw`) is imported using the adm
 1. Click PMode and then Parties.
 2. Select the party `org2_gw` and click Edit.
 3. Click the Import button in the Certificate section.
-4. Select the certificate to be imported.
+4. Select the certificate to be imported (`org2_sign_certificate.cer`).
 5. Click OK and then click Save.
 
 The TLS certificate is imported on the command line. The TLS truststore is located in `/etc/harmony-ap/tls-truststore.jks`. 
@@ -558,7 +558,7 @@ The sign certificate of the Access Point 1 (`org1_gw`) is imported using the adm
 1. Click PMode and then Parties.
 2. Select the party `org1_gw` and click Edit.
 3. Click the Import button in the Certificate section.
-4. Select the certificate to be imported.
+4. Select the certificate to be imported (`org1_sign_certificate.cer`).
 5. Click OK and then click Save.
 
 The TLS certificate is imported on the command line. The TLS truststore is located in `/etc/harmony-ap/tls-truststore.jks`. 

--- a/doc/static_discovery_configuration_guide.md
+++ b/doc/static_discovery_configuration_guide.md
@@ -270,7 +270,7 @@ checks can be adjusted using the following properties in the `/etc/harmony-ap/do
 
 See the Domibus Administration Guide \[[DOMIBUS_ADMIN_GUIDE](#Ref_DOMIBUS_ADMIN_GUIDE)\] for more details regarding different configuration alternatives.
 
-### 2.4.1 Import Trusted Sign Certificates
+#### 2.4.1 Import Trusted Sign Certificates
 
 The channel where trusted sign certificates of data exchange parties are distributed or published varies between 
 different eDelivery policy domains. If you don't know where to get them, please contact the domain authority of 
@@ -288,7 +288,7 @@ for a specific party can be imported following the steps below:
 4. Select the certificate to be imported.
 5. Click OK and then click Save.
 
-### 2.4.2 Import Trusted TLS Certificates
+#### 2.4.2 Import Trusted TLS Certificates
 
 The channel where trusted TLS certificates of data exchange parties are distributed or published varies between 
 different eDelivery policy domains. If you don't know where to get them, please contact the domain authority of 
@@ -334,7 +334,7 @@ different eDelivery policy domains. If you're not sure where to publish them, pl
 the policy domain where the Access Point is registered. Whatever the channel is, the first step is to export the certificates
 from sign and TLS keystores.
 
-### 2.5.1 Export Sign Certificates
+#### 2.5.1 Export Sign Certificates
 
 A sign certificate belonging to a specific party can be exported using the following command:
 
@@ -354,7 +354,7 @@ A sign key can be deleted using the following command:
 sudo keytool -delete -noprompt -alias <party_name> -keystore /etc/harmony-ap/ap-keystore.jks -storepass <ap_keystore_password>
 ```
 
-### 2.5.2 Export TLS Certificates
+#### 2.5.2 Export TLS Certificates
 
 The default TLS certificate that's created during the installation process can be exported using the following command:
 

--- a/packaging/common/ap/clientauthentication.xml.template
+++ b/packaging/common/ap/clientauthentication.xml.template
@@ -1,0 +1,8 @@
+<http-conf:tlsClientParameters disableCNCheck="false" secureSocketProtocol="TLSv1.2"
+                               xmlns:http-conf="http://cxf.apache.org/transports/http/configuration"
+                               xmlns:security="http://cxf.apache.org/configuration/security">
+    <security:trustManagers>
+        <security:keyStore type="JKS" password="{{tls_truststore_password}}"
+                           file="/etc/harmony-ap/tls-truststore.jks"/>
+    </security:trustManagers>
+</http-conf:tlsClientParameters>

--- a/packaging/common/ap/domibus.properties.template
+++ b/packaging/common/ap/domibus.properties.template
@@ -41,7 +41,7 @@ domibus.security.keystore.password={{keystorepass}}
 
 #Private key
 #The alias from the keystore of the private key
-domibus.security.key.private.alias=selfsigned
+domibus.security.key.private.alias={{partyname}}
 
 #The private key password
 domibus.security.key.private.password={{keystorepass}}

--- a/packaging/common/ap/server.xml.template
+++ b/packaging/common/ap/server.xml.template
@@ -87,6 +87,8 @@
                secure="true"
                keystoreFile="/etc/harmony-ap/tls-keystore.jks"
                keystorePass="{{tls_keystore_password}}"
+               truststoreFile="/etc/harmony-ap/tls-truststore.jks"
+               truststorePass="{{tls_truststore_password}}"
                clientAuth="want"
                sslProtocol="TLS"
     />

--- a/packaging/ubuntu/generic/harmony-ap.config
+++ b/packaging/ubuntu/generic/harmony-ap.config
@@ -17,6 +17,7 @@ if [ "$1" = "configure" ] || [ "$1" = "reconfigure" ]; then
   db_beginblock
   db_input high harmony-ap/adminuser || true
   db_input high harmony-ap/adminpassword || true
+  db_input high harmony-ap/partyname || true
   db_input high harmony-ap/serverdn || true
   db_endblock
   db_go

--- a/packaging/ubuntu/generic/harmony-ap.install
+++ b/packaging/ubuntu/generic/harmony-ap.install
@@ -12,6 +12,7 @@
 ../../../../common/ap/harmony_ap_schema.ddl /opt/harmony-ap/setup/
 ../../../../common/ap/domibus.properties.template /opt/harmony-ap/setup/
 ../../../../common/ap/server.xml.template /opt/harmony-ap/setup/
+../../../../common/ap/clientauthentication.xml.template /opt/harmony-ap/setup/
 ../../../../common/ap/eDeliveryAS4Policy.xml /etc/harmony-ap/policies/
 ../../../../common/ap/eDeliveryAS4Policy_BST.xml /etc/harmony-ap/policies/
 ../../../../common/ap/eDeliveryAS4Policy_BST_PKIP.xml /etc/harmony-ap/policies/

--- a/packaging/ubuntu/generic/harmony-ap.postinst
+++ b/packaging/ubuntu/generic/harmony-ap.postinst
@@ -14,7 +14,7 @@ cleanup() {
   if [ ! "$SUCCESS" = true ]; then
     rm -f /etc/harmony-ap/*.jks
     if [ "$DROPDBONERROR" = true ]; then
-      mysql -e "DROP SCHEMA harmony_ap; DROP USER harmony@localhost"
+      mysql -e "DROP SCHEMA harmony_ap; DROP USER harmony_ap@localhost"
     fi;
   fi
 }
@@ -74,6 +74,7 @@ case "$1" in
     KEYSTOREPASS=$(openssl rand -base64 12)
     TRUSTSTOREPASS=$(openssl rand -base64 12)
     TLSKEYPASS=$(openssl rand -base64 12)
+    TLSTRUSTSTOREPASS=$(openssl rand -base64 12)
 
     keytool -genkeypair -keyalg RSA -alias selfsigned -keystore /etc/harmony-ap/ap-keystore.jks -storepass $KEYSTOREPASS \
       -keypass $KEYSTOREPASS -validity 333 -keysize 3096 -dname "$SERVERDN" 2>/dev/null
@@ -85,15 +86,22 @@ case "$1" in
       -keypass $TRUSTSTOREPASS -dname "CN=mock" 2>/dev/null
     keytool -delete -alias mock -keystore /etc/harmony-ap/ap-truststore.jks -storepass $TRUSTSTOREPASS 2>/dev/null
 
+    keytool -export -alias selfsigned -file /etc/harmony-ap/selfsigned.cer \
+      -keystore /etc/harmony-ap/tls-keystore.jks -storepass $TLSKEYPASS 2>/dev/null
+    keytool -import -noprompt -alias selfsigned -file /etc/harmony-ap/selfsigned.cer \
+      -keystore /etc/harmony-ap/tls-truststore.jks -storepass $TLSTRUSTSTOREPASS 2>/dev/null
+    rm -f /etc/harmony-ap/selfsigned.cer
+
     E_KEYSTOREPASS=$(escape_for_sed "$KEYSTOREPASS")
     E_TRUSTSTOREPASS=$(escape_for_sed "$TRUSTSTOREPASS")
     E_DBUSER=$(escape_for_sed "$DBUSER")
     E_DBPASSWORD=$(escape_for_sed "$DBPASSWORD")
     E_TLSKEYPASS=$(escape_for_sed "$TLSKEYPASS")
+    E_TLSTRUSTSTOREPASS=$(escape_for_sed "$TLSTRUSTSTOREPASS")
     E_SMLZONE=$(escape_for_sed "$SMLZONE")
 
-
-    sed -e "s/{{tls_keystore_password}}/$E_TLSKEYPASS/" /opt/harmony-ap/setup/server.xml.template > /etc/harmony-ap/tomcat-conf/server.xml
+    sed -e "s/{{tls_keystore_password}}/$E_TLSKEYPASS/" -e "s/{{tls_truststore_password}}/$E_TLSTRUSTSTOREPASS/" \
+        /opt/harmony-ap/setup/server.xml.template > /etc/harmony-ap/tomcat-conf/server.xml
 
     sed -e "s/{{keystorepass}}/$E_KEYSTOREPASS/" -e "s/{{truststorepass}}/$E_TRUSTSTOREPASS/" \
       -e "s/{{dbuser}}/$E_DBUSER/" -e "s/{{dbpassword}}/$E_DBPASSWORD/" \
@@ -108,7 +116,7 @@ case "$1" in
       echo "The Harmony AP system user must not have uid 0 (root).Please fix this and reinstall this package." >&2
       exit 1
   fi
-  if [ "`id -g harmony`" -eq 0 ]; then
+  if [ "`id -g harmony-ap`" -eq 0 ]; then
       echo "The Harmony AP system user must not have root as primary group. Please fix this and reinstall this package." >&2
       exit 1
   fi

--- a/packaging/ubuntu/generic/harmony-ap.postinst
+++ b/packaging/ubuntu/generic/harmony-ap.postinst
@@ -35,6 +35,8 @@ case "$1" in
   AUSER="$RET"
   db_get harmony-ap/adminpassword
   APASSWORD="$RET"
+  db_get harmony-ap/partyname
+  PARTYNAME="$RET"
   db_get harmony-ap/serverdn
   SERVERDN="$RET"
   db_stop
@@ -76,19 +78,19 @@ case "$1" in
     TLSKEYPASS=$(openssl rand -base64 12)
     TLSTRUSTSTOREPASS=$(openssl rand -base64 12)
 
-    keytool -genkeypair -keyalg RSA -alias selfsigned -keystore /etc/harmony-ap/ap-keystore.jks -storepass $KEYSTOREPASS \
+    keytool -genkeypair -keyalg RSA -alias $PARTYNAME -keystore /etc/harmony-ap/ap-keystore.jks -storepass $KEYSTOREPASS \
       -keypass $KEYSTOREPASS -validity 333 -keysize 3096 -dname "$SERVERDN" 2>/dev/null
 
-    keytool -genkeypair -keyalg RSA -alias selfsigned -keystore /etc/harmony-ap/tls-keystore.jks -storepass $TLSKEYPASS \
+    keytool -genkeypair -keyalg RSA -alias $PARTYNAME -keystore /etc/harmony-ap/tls-keystore.jks -storepass $TLSKEYPASS \
       -keypass $TLSKEYPASS -validity 333 -keysize 3096 -dname "$SERVERDN" 2>/dev/null
 
     keytool -genkeypair -alias mock -keystore /etc/harmony-ap/ap-truststore.jks -storepass $TRUSTSTOREPASS \
       -keypass $TRUSTSTOREPASS -dname "CN=mock" 2>/dev/null
     keytool -delete -alias mock -keystore /etc/harmony-ap/ap-truststore.jks -storepass $TRUSTSTOREPASS 2>/dev/null
 
-    keytool -export -alias selfsigned -file /etc/harmony-ap/selfsigned.cer \
+    keytool -export -alias $PARTYNAME -file /etc/harmony-ap/selfsigned.cer \
       -keystore /etc/harmony-ap/tls-keystore.jks -storepass $TLSKEYPASS 2>/dev/null
-    keytool -import -noprompt -alias selfsigned -file /etc/harmony-ap/selfsigned.cer \
+    keytool -import -noprompt -alias $PARTYNAME -file /etc/harmony-ap/selfsigned.cer \
       -keystore /etc/harmony-ap/tls-truststore.jks -storepass $TLSTRUSTSTOREPASS 2>/dev/null
     rm -f /etc/harmony-ap/selfsigned.cer
 
@@ -99,6 +101,7 @@ case "$1" in
     E_TLSKEYPASS=$(escape_for_sed "$TLSKEYPASS")
     E_TLSTRUSTSTOREPASS=$(escape_for_sed "$TLSTRUSTSTOREPASS")
     E_SMLZONE=$(escape_for_sed "$SMLZONE")
+    E_PARTYNAME=$(escape_for_sed "$PARTYNAME")
 
     sed -e "s/{{tls_keystore_password}}/$E_TLSKEYPASS/" -e "s/{{tls_truststore_password}}/$E_TLSTRUSTSTOREPASS/" \
         /opt/harmony-ap/setup/server.xml.template > /etc/harmony-ap/tomcat-conf/server.xml
@@ -109,6 +112,7 @@ case "$1" in
     sed -e "s/{{keystorepass}}/$E_KEYSTOREPASS/" -e "s/{{truststorepass}}/$E_TRUSTSTOREPASS/" \
       -e "s/{{dbuser}}/$E_DBUSER/" -e "s/{{dbpassword}}/$E_DBPASSWORD/" \
       -e "s/{{dynamicdiscovery}}/$USEDYNAMIC/" -e "s/{{smlzone}}/$E_SMLZONE/" \
+      -e "s/{{partyname}}/$E_PARTYNAME/" \
         /opt/harmony-ap/setup/domibus.properties.template > /etc/harmony-ap/domibus.properties
   fi
 

--- a/packaging/ubuntu/generic/harmony-ap.postinst
+++ b/packaging/ubuntu/generic/harmony-ap.postinst
@@ -103,6 +103,9 @@ case "$1" in
     sed -e "s/{{tls_keystore_password}}/$E_TLSKEYPASS/" -e "s/{{tls_truststore_password}}/$E_TLSTRUSTSTOREPASS/" \
         /opt/harmony-ap/setup/server.xml.template > /etc/harmony-ap/tomcat-conf/server.xml
 
+    sed -e "s/{{tls_truststore_password}}/$E_TLSTRUSTSTOREPASS/" \
+        /opt/harmony-ap/setup/clientauthentication.xml.template > /etc/harmony-ap/clientauthentication.xml
+
     sed -e "s/{{keystorepass}}/$E_KEYSTOREPASS/" -e "s/{{truststorepass}}/$E_TRUSTSTOREPASS/" \
       -e "s/{{dbuser}}/$E_DBUSER/" -e "s/{{dbpassword}}/$E_DBPASSWORD/" \
       -e "s/{{dynamicdiscovery}}/$USEDYNAMIC/" -e "s/{{smlzone}}/$E_SMLZONE/" \

--- a/packaging/ubuntu/generic/harmony-ap.templates
+++ b/packaging/ubuntu/generic/harmony-ap.templates
@@ -10,12 +10,17 @@ Description: eDelivery SML zone
 Template: harmony-ap/adminuser
 Type: string
 Default: harmony
-Description: Harmony Accesspoint administator user name
+Description: Harmony Access Point administator username
 
 Template: harmony-ap/adminpassword
 Type: password
-Description: Harmony Accesspoint administator initial password
+Description: Harmony Access Point administator initial password
 
 Template: harmony-ap/serverdn
 Type: string
-Description: Distinguished name of generated selfsigned server certificate
+Description: Distinguished name of generated self-signed server certificate
+
+Template: harmony-ap/partyname
+Type: string
+Default: selfsigned
+Description: Harmony Access Point owner Party Name


### PR DESCRIPTION
- Create TLS truststore during installation [NEDS-71 ](https://jira.niis.org/browse/NEDS-71)
  - Create TLS truststore automatically during installation.
  - Import the public certificate of the private TLS key to the TLS truststore.
  - Fix errors in keytool commands in the Static Discovery Configuration Guide.
  - Fix incorrect DB username in the postinstall script.
  - Fix incorrect group name in the postinstall script.
  - Add the TLS truststore configuration in the Tomcat default configuration.
- Create One-Way SSL configuration during installation [NEDS-72](https://jira.niis.org/browse/NEDS-72)
  - Create `/etc/harmony-ap/clientauthentication.xml` configuration file.
  - Set the TLS truststore password.
- Prompt Party Name during installation process [NEDS-75](https://jira.niis.org/browse/NEDS-75)
  - Prompt Party Name during installation process.
  - Use the given Party Name as sign and TLS key alias.
  - Update the alias in domibus.properties.
- Update AP installation guide.
- Update static discovery configuration guide.