### PR TITLE
NEDS-79

### DIFF
--- a/packaging/common/ap/server.xml.template
+++ b/packaging/common/ap/server.xml.template
@@ -152,6 +152,9 @@
       <Host name="localhost"  appBase="webapps"
             unpackWARs="true" autoDeploy="true">
 
+      <Valve className="org.apache.catalina.valves.ErrorReportValve"
+             showReport="false" showServerInfo="false" />
+
         <!-- SingleSignOn valve, share authentication between web applications
              Documentation at: /docs/config/valve.html -->
         <!--

--- a/packaging/common/smp/server.xml.template
+++ b/packaging/common/smp/server.xml.template
@@ -145,6 +145,9 @@
       <Host name="localhost"  appBase="webapps"
             unpackWARs="true" autoDeploy="true">
 
+      <Valve className="org.apache.catalina.valves.ErrorReportValve"
+             showReport="false" showServerInfo="false" />
+             
         <!-- SingleSignOn valve, share authentication between web applications
              Documentation at: /docs/config/valve.html -->
         <!--


### PR DESCRIPTION
- [NEDS-79](https://jira.niis.org/browse/NEDS-79)
  - Hide details from AP error pages.
- [NEDS-80](https://jira.niis.org/browse/NEDS-80)
  - Hide details from SMP error pages.

Use Tomcat's `ErrorReportValve` to set `showReport` and `showServerInfo` to `false`.

> **showReport**
>
> Flag to determine if the error report (custom error message and/or            stack trace) is presented when an error occurs. If set to            false, then the error report is not returned in the HTML            response.            Default value: true

> **showServerInfo**
>
> Flag to determine if server information is presented when an error occurs. If set to false, then the server version is not returned in the HTML response. Default value: true


