### PR TITLE
NEDS-24 AP support for version upgrade

### DIFF
--- a/doc/harmony-ap_installation_guide.md
+++ b/doc/harmony-ap_installation_guide.md
@@ -1,6 +1,6 @@
 # Harmony eDelivery Access - Access Point Installation Guide <!-- omit in toc -->
 
-Version: 1.2  
+Version: 1.3  
 Doc. ID: IG-AP
 
 ---
@@ -12,6 +12,7 @@ Doc. ID: IG-AP
  15.11.2021 | 1.0     | Initial version                                                         |
  07.01.2022 | 1.1     | Add reference to the Static Discovery Configuration Guide \[UG-SDCG\]   | Petteri Kivimäki
  08.01.2022 | 1.2     | Add party name to section [2.5](#25-access-point-installation) and TLS truststore to section [2.10](#210-location-of-configuration-and-generated-passwords) | Petteri Kivimäki
+ 04.02.2022 | 1.3     | Add upgrade instructions                                                | Petteri Kivimäki
  
 ## License <!-- omit in toc -->
 
@@ -36,6 +37,7 @@ To view a copy of this license, visit <https://creativecommons.org/licenses/by-s
   - [2.8 Installing Custom Plugins](#28-installing-custom-plugins)
   - [2.9 Changes made to system during installation](#29-changes-made-to-system-during-installation)
   - [2.10 Location of configuration and generated passwords](#210-location-of-configuration-and-generated-passwords)
+- [3 Version Upgrade](#3-version-upgrade)
  
 ## 1 Introduction
 
@@ -62,7 +64,7 @@ See eDelivery definitions documentation \[[TERMS](#Ref_TERMS)\].
 5. <a id="Ref_UG-DDCG" class="anchor"></a>\[UG-DDCG\] Harmony eDelivery Access - Dynamic Discovery Configuration Guide. Document ID: [UG-DDCG](dynamic_discovery_configuration_guide.md)
 6. <a id="Ref_UG-SDCG" class="anchor"></a>\[UG-SDCG\] Harmony eDelivery Access - Static Discovery Configuration Guide. Document ID: [UG-SDCG](static_discovery_configuration_guide.md)
 
-## 2. Installation
+## 2 Installation
 
 ### 2.1 Prerequisites to Installation
 
@@ -228,3 +230,30 @@ During the installation process, multiple random passwords are generated.
 | Content encryption truststore (`/etc/harmony-ap/ap-truststore.jks`) password | Configuration file: `/etc/harmony-ap/domibus.properties`<br /><br />Properties: `domibus.security.truststore.password`. Content of this keystore can be changed using the administrative UI. |
 | TLS keystore (`/etc/harmony-ap/tls-keystore.jks`) password | Configuration file: `/etc/harmony-ap/conf/server.xml`<br /><br />Property: `keystorePass` |
 | TLS truststore (`/etc/harmony-ap/tls-truststore.jks`) password | Configuration file: `/etc/harmony-ap/conf/server.xml`<br /><br />Property: `truststorePass` |
+
+## 3 Version Upgrade
+
+Before upgrading the Access Point, stop the `harmony-ap` service:
+```bash
+sudo systemctl stop harmony-ap
+```
+
+Update package repository metadata:
+```bash
+sudo apt update
+```
+
+Issue the following command to run the upgrade:
+```bash
+sudo apt upgrade
+```
+
+Once the upgrade has been completed, reload the `harmony-ap` service configuration files:
+```bash
+sudo systemctl daemon-reload
+```
+
+Start the `harmony-ap` service:
+```bash
+sudo systemctl stop harmony-ap
+```

--- a/doc/harmony-ap_installation_guide.md
+++ b/doc/harmony-ap_installation_guide.md
@@ -260,5 +260,5 @@ sudo systemctl daemon-reload
 
 Start the `harmony-ap` service:
 ```bash
-sudo systemctl stop harmony-ap
+sudo systemctl start harmony-ap
 ```

--- a/doc/harmony-ap_installation_guide.md
+++ b/doc/harmony-ap_installation_guide.md
@@ -239,8 +239,7 @@ The Access Point application log files are located in the `/var/log/harmony-ap/`
 ## 3 Version Upgrade
 
 The the `harmony-ap` service is automatically stopped for the upgrade and automatically restarted after the upgrade if
-starting the service at system startup has been enabled.
-
+the service has been enabled. Otherwise, the service must be manually restarted after the upgrade.
 
 Update package repository metadata:
 ```bash

--- a/doc/harmony-ap_installation_guide.md
+++ b/doc/harmony-ap_installation_guide.md
@@ -12,7 +12,7 @@ Doc. ID: IG-AP
  15.11.2021 | 1.0     | Initial version                                                         |
  07.01.2022 | 1.1     | Add reference to the Static Discovery Configuration Guide \[UG-SDCG\]   | Petteri Kivimäki
  08.01.2022 | 1.2     | Add party name to section [2.5](#25-access-point-installation) and TLS truststore to section [2.10](#210-location-of-configuration-and-generated-passwords) | Petteri Kivimäki
- 04.02.2022 | 1.3     | Add upgrade instructions                                                | Petteri Kivimäki
+ 04.02.2022 | 1.3     | Add upgrade instructions. Add section about log files                   | Petteri Kivimäki
  
 ## License <!-- omit in toc -->
 
@@ -37,6 +37,7 @@ To view a copy of this license, visit <https://creativecommons.org/licenses/by-s
   - [2.8 Installing Custom Plugins](#28-installing-custom-plugins)
   - [2.9 Changes made to system during installation](#29-changes-made-to-system-during-installation)
   - [2.10 Location of configuration and generated passwords](#210-location-of-configuration-and-generated-passwords)
+  - [2.11 Log Files](#211-log-files)
 - [3 Version Upgrade](#3-version-upgrade)
  
 ## 1 Introduction
@@ -230,6 +231,10 @@ During the installation process, multiple random passwords are generated.
 | Content encryption truststore (`/etc/harmony-ap/ap-truststore.jks`) password | Configuration file: `/etc/harmony-ap/domibus.properties`<br /><br />Properties: `domibus.security.truststore.password`. Content of this keystore can be changed using the administrative UI. |
 | TLS keystore (`/etc/harmony-ap/tls-keystore.jks`) password | Configuration file: `/etc/harmony-ap/conf/server.xml`<br /><br />Property: `keystorePass` |
 | TLS truststore (`/etc/harmony-ap/tls-truststore.jks`) password | Configuration file: `/etc/harmony-ap/conf/server.xml`<br /><br />Property: `truststorePass` |
+
+### 2.11 Log Files
+
+The Access Point application log files are located in the `/var/log/harmony-ap/` directory.
 
 ## 3 Version Upgrade
 

--- a/doc/harmony-ap_installation_guide.md
+++ b/doc/harmony-ap_installation_guide.md
@@ -238,10 +238,9 @@ The Access Point application log files are located in the `/var/log/harmony-ap/`
 
 ## 3 Version Upgrade
 
-Before upgrading the Access Point, stop the `harmony-ap` service:
-```bash
-sudo systemctl stop harmony-ap
-```
+The the `harmony-ap` service is automatically stopped for the upgrade and automatically restarted after the upgrade if
+starting the service at system startup has been enabled.
+
 
 Update package repository metadata:
 ```bash
@@ -253,12 +252,8 @@ Issue the following command to run the upgrade:
 sudo apt upgrade
 ```
 
-Once the upgrade has been completed, reload the `harmony-ap` service configuration files:
-```bash
-sudo systemctl daemon-reload
-```
-
-Start the `harmony-ap` service:
+If starting the service at system startup hasn't been enabled, the `harmony-ap` service must be started manually after
+the upgrade:
 ```bash
 sudo systemctl start harmony-ap
 ```

--- a/packaging/common/ap/setenv.sh
+++ b/packaging/common/ap/setenv.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+export JAVA_OPTS="$JAVA_OPTS -Djava.protocol.handler.pkgs=org.apache.catalina.webresources \
+   -Ddomibus.config.location=/etc/harmony-ap -Ddomibus.work.location=/opt/harmony-ap/work"

--- a/packaging/ubuntu/generic/harmony-ap.install
+++ b/packaging/ubuntu/generic/harmony-ap.install
@@ -6,6 +6,7 @@
 ../../../../commonbin/tomcat9/lib/* /opt/harmony-ap/lib/
 ../../../../commonbin/tomcat9/conf/* /etc/harmony-ap/tomcat-conf/
 ../../../../common/ap/logging.properties /etc/harmony-ap/tomcat-conf/
+../../../../common/ap/setenv.sh /opt/harmony-ap/setup/
 ../../../../common/ap/setenv.sh.template /opt/harmony-ap/setup/
 ../../../../common/ap/activemq.xml /etc/harmony-ap/internal/
 ../../../../common/ap/logback.xml /etc/harmony-ap/

--- a/packaging/ubuntu/generic/harmony-ap.postinst
+++ b/packaging/ubuntu/generic/harmony-ap.postinst
@@ -150,8 +150,10 @@ case "$1" in
   chown -R harmony-ap:harmony-ap /etc/harmony-ap
   chmod -R 0751 /etc/harmony-ap
 
-  systemctl daemon-reload
-  systemctl start harmony-ap >/dev/null || true
+  if [ "$(systemctl is-enabled harmony-ap)" = "enabled" ]; then
+    systemctl daemon-reload
+    systemctl start harmony-ap >/dev/null || true
+  fi
 
   SUCCESS=true
  ;;

--- a/packaging/ubuntu/generic/harmony-ap.postinst
+++ b/packaging/ubuntu/generic/harmony-ap.postinst
@@ -64,11 +64,9 @@ case "$1" in
         INSERT INTO harmony_ap.TB_USER_ROLES (USER_ID, ROLE_ID) VALUES ('1', '1');"
   else
     echo "Schema harmony_ap already exists. Skipping schema creation" >&2
-    DBPASSWORD=$(openssl rand -base64 12)
-    mysql -e \
-      "ALTER USER $DBUSER@localhost IDENTIFIED BY '$DBPASSWORD'; \
-       FLUSH PRIVILEGES;"
   fi
+
+  mkdir -p /etc/harmony-ap/bin
 
   if [ ! -f /etc/harmony-ap/domibus.properties ]; then
     rm -f /etc/harmony-ap/*.jks
@@ -116,7 +114,16 @@ case "$1" in
         /opt/harmony-ap/setup/domibus.properties.template > /etc/harmony-ap/domibus.properties
 
     sed -e "s/{{tls_truststore_password}}/$E_TLSTRUSTSTOREPASS/" \
-        /opt/harmony-ap/setup/setenv.sh.template > /opt/harmony-ap/bin/setenv.sh
+        /opt/harmony-ap/setup/setenv.sh.template > /etc/harmony-ap/bin/setenv.sh
+  fi
+
+  # Required to support upgrade from 1.0.0 to 1.1.0
+  if [ ! -f /etc/harmony-ap/bin/setenv.sh ]; then
+    cp /opt/harmony-ap/setup/setenv.sh /etc/harmony-ap/bin/setenv.sh
+  fi
+
+  if [ ! -f /opt/harmony-ap/bin/setenv.sh ]; then
+    ln -s /etc/harmony-ap/bin/setenv.sh /opt/harmony-ap/bin/setenv.sh
   fi
 
   adduser --system --quiet --no-create-home --shell /usr/sbin/nologin --group --gecos "Harmony user" harmony-ap

--- a/packaging/ubuntu/generic/harmony-ap.postinst
+++ b/packaging/ubuntu/generic/harmony-ap.postinst
@@ -66,8 +66,6 @@ case "$1" in
     echo "Schema harmony_ap already exists. Skipping schema creation" >&2
   fi
 
-  mkdir -p /etc/harmony-ap/bin
-
   if [ ! -f /etc/harmony-ap/domibus.properties ]; then
     rm -f /etc/harmony-ap/*.jks
 
@@ -114,19 +112,19 @@ case "$1" in
         /opt/harmony-ap/setup/domibus.properties.template > /etc/harmony-ap/domibus.properties
 
     sed -e "s/{{tls_truststore_password}}/$E_TLSTRUSTSTOREPASS/" \
-        /opt/harmony-ap/setup/setenv.sh.template > /etc/harmony-ap/bin/setenv.sh
+        /opt/harmony-ap/setup/setenv.sh.template > /opt/harmony-ap/bin/setenv.sh
   fi
 
   # Required to support upgrade from 1.0.0 to 1.1.0
-  if [ ! -f /etc/harmony-ap/bin/setenv.sh ]; then
-    cp /opt/harmony-ap/setup/setenv.sh /etc/harmony-ap/bin/setenv.sh
-  fi
-
   if [ ! -f /opt/harmony-ap/bin/setenv.sh ]; then
-    ln -s /etc/harmony-ap/bin/setenv.sh /opt/harmony-ap/bin/setenv.sh
+    echo "Create /opt/harmony-ap/bin/setenv.sh file" >&2
+    cp /opt/harmony-ap/setup/setenv.sh /opt/harmony-ap/bin/setenv.sh
   fi
 
-  adduser --system --quiet --no-create-home --shell /usr/sbin/nologin --group --gecos "Harmony user" harmony-ap
+  # Make sure the administrative user exists
+  if ! getent passwd harmony-ap > /dev/null; then
+    adduser --system --quiet --no-create-home --shell /usr/sbin/nologin --group --gecos "Harmony user" harmony-ap
+  fi
 
   # check validity of user and group
   if [ "`id -u harmony-ap`" -eq 0 ]; then

--- a/packaging/ubuntu/generic/harmony-ap.postinst
+++ b/packaging/ubuntu/generic/harmony-ap.postinst
@@ -152,7 +152,7 @@ case "$1" in
 
   if [ "$(systemctl is-enabled harmony-ap)" = "enabled" ]; then
     systemctl daemon-reload
-    systemctl start harmony-ap >/dev/null || true
+    systemctl start harmony-ap 2>/dev/null || true
   fi
 
   SUCCESS=true

--- a/packaging/ubuntu/generic/harmony-ap.postinst
+++ b/packaging/ubuntu/generic/harmony-ap.postinst
@@ -150,6 +150,9 @@ case "$1" in
   chown -R harmony-ap:harmony-ap /etc/harmony-ap
   chmod -R 0751 /etc/harmony-ap
 
+  systemctl daemon-reload
+  systemctl start harmony-ap >/dev/null || true
+
   SUCCESS=true
  ;;
 

--- a/packaging/ubuntu/generic/harmony-ap.preinst
+++ b/packaging/ubuntu/generic/harmony-ap.preinst
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+if [ "$1" = "upgrade" ]; then
+  systemctl stop harmony-ap >/dev/null || true
+fi

--- a/packaging/ubuntu/generic/harmony-ap.preinst
+++ b/packaging/ubuntu/generic/harmony-ap.preinst
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 if [ "$1" = "upgrade" ]; then
-  systemctl stop harmony-ap >/dev/null || true
+  systemctl stop harmony-ap 2>/dev/null || true
 fi

--- a/packaging/ubuntu/generic/harmony-ap.prerm
+++ b/packaging/ubuntu/generic/harmony-ap.prerm
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+
+systemctl stop harmony-ap >/dev/null || true

--- a/packaging/ubuntu/generic/harmony-ap.prerm
+++ b/packaging/ubuntu/generic/harmony-ap.prerm
@@ -1,4 +1,0 @@
-#!/bin/bash
-set -e
-
-systemctl stop harmony-ap >/dev/null || true


### PR DESCRIPTION
Add support for version upgrades using `apt upgrade`:

- Skip all DB operations if schema already exists.
- Add check that the administrative user exists.
- Recreate `/opt/harmony-ap/bin/setenv.sh` after upgrade from version 1.0.0 to 1.x.x.
- Add upgrade instructions to AP installation guide.
- Add section about log files to the installation guide.

JIRA: https://jira.niis.org/browse/NEDS-24