### PR TITLE
NEDS-25 SMP support for version upgrade

### DIFF
--- a/doc/harmony-smp_installation_guide.md
+++ b/doc/harmony-smp_installation_guide.md
@@ -1,6 +1,6 @@
 # Harmony eDelivery Access - Service Metadata Publisher Installation Guide <!-- omit in toc -->
 
-Version: 1.4  
+Version: 1.5  
 Doc. ID: IG-SMP
 
 ---
@@ -14,6 +14,7 @@ Doc. ID: IG-SMP
  21.12.2021 | 1.2     | Add section [2.11 Securing SMP user interface](#211-securing-smp-user-interface) | Andres Allkivi
  07.01.2021 | 1.3     | Add language types to code blocks                               | Petteri Kivimäki
  22.01.2021 | 1.4     | Add more information about keystores and trustores. Add information about properties stored in database | Petteri Kivimäki
+ 06.02.2021 | 1.5     | Add upgrade instructions                                        | Petteri Kivimäki
  
 ## License <!-- omit in toc -->
 
@@ -39,6 +40,7 @@ To view a copy of this license, visit <https://creativecommons.org/licenses/by-s
   - [2.9 Changes made to system during installation](#29-changes-made-to-system-during-installation)
   - [2.10 Location of configuration and generated passwords](#210-location-of-configuration-and-generated-passwords)
   - [2.11 Securing SMP user interface](#211-securing-smp-user-interface)
+- [3 Version Upgrade](#3-version-upgrade)
 
 ## 1 Introduction
 
@@ -292,3 +294,30 @@ Example assuming proxy IP address is `192.168.1.1`:
 
 Please note that when registering SMP with SML, the externally visible address and hostname have to be used, i.e., the
 address and hostname of reverse proxy, not address and hostname of SMP.
+
+## 3 Version Upgrade
+
+Before upgrading the SMP, stop the `harmony-smp` service:
+```bash
+sudo systemctl stop harmony-smp
+```
+
+Update package repository metadata:
+```bash
+sudo apt update
+```
+
+Issue the following command to run the upgrade:
+```bash
+sudo apt upgrade
+```
+
+Once the upgrade has been completed, reload the `harmony-smp` service configuration files:
+```bash
+sudo systemctl daemon-reload
+```
+
+Start the `harmony-smp` service:
+```bash
+sudo systemctl stop harmony-smp
+```

--- a/packaging/common/smp/setenv.sh
+++ b/packaging/common/smp/setenv.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+export CLASSPATH=/etc/harmony-smp

--- a/packaging/ubuntu/generic/harmony-smp.install
+++ b/packaging/ubuntu/generic/harmony-smp.install
@@ -6,6 +6,7 @@
 ../../../../commonbin/tomcat9/bin/*.jar /opt/harmony-smp/bin/
 ../../../../commonbin/tomcat9/lib/* /opt/harmony-smp/lib/
 ../../../../commonbin/tomcat9/conf/* /etc/harmony-smp/tomcat-conf/
+../../../../common/smp/setenv.sh /opt/harmony-smp/setup/
 ../../../../common/smp/setenv.sh.template /opt/harmony-smp/setup/
 ../../../../common/smp/logging.properties /etc/harmony-smp/tomcat-conf/
 ../../../../common/smp/harmony_smp_schema.ddl /opt/harmony-smp/setup/

--- a/packaging/ubuntu/generic/harmony-smp.postinst
+++ b/packaging/ubuntu/generic/harmony-smp.postinst
@@ -96,54 +96,64 @@ case "$1" in
          VALUES ('configuration.dir', '/etc/harmony-smp/', NOW(), NOW());"
   else
     echo "Schema harmony_smp already exists. Skipping schema creation" >&2
-    mysql -e \
-      "ALTER USER $DBUSER@localhost IDENTIFIED BY '$DBPASSWORD'; \
-       FLUSH PRIVILEGES;"
   fi
 
-  KEYSTOREPASS=$(openssl rand -base64 12)
-  keytool -genkeypair -keyalg RSA -alias selfsigned -keystore /etc/harmony-smp/smp-keystore.jks -storepass $KEYSTOREPASS \
-    -keypass $KEYSTOREPASS -validity 333 -keysize 3072 -dname "$SERVERDN" 2>/dev/null
+  if [ ! -f /etc/harmony-smp/tomcat-conf/server.xml ]; then
+    rm -f /etc/harmony-smp/*.jks
 
-  mysql harmony_smp -e  "INSERT INTO SMP_CONFIGURATION (PROPERTY, VALUE, CREATED_ON, LAST_UPDATED_ON)
+    KEYSTOREPASS=$(openssl rand -base64 12)
+    keytool -genkeypair -keyalg RSA -alias selfsigned -keystore /etc/harmony-smp/smp-keystore.jks -storepass $KEYSTOREPASS \
+        -keypass $KEYSTOREPASS -validity 333 -keysize 3072 -dname "$SERVERDN" 2>/dev/null
+
+    mysql harmony_smp -e  "INSERT INTO SMP_CONFIGURATION (PROPERTY, VALUE, CREATED_ON, LAST_UPDATED_ON)
          VALUES ('smp.keystore.password', '{DEC}{$KEYSTOREPASS}', NOW(), NOW())
          ON DUPLICATE KEY UPDATE VALUE='{DEC}{$KEYSTOREPASS}', LAST_UPDATED_ON=NOW();"
 
-  TLSKEYPASS=$(openssl rand -base64 12)
-  keytool -genkeypair -keyalg RSA -alias selfsigned -keystore /etc/harmony-smp/tls-keystore.jks -storepass $TLSKEYPASS \
-    -keypass $TLSKEYPASS -validity 333 -keysize 3072 -dname "$SERVERDN" 2>/dev/null
+    TLSKEYPASS=$(openssl rand -base64 12)
+    keytool -genkeypair -keyalg RSA -alias selfsigned -keystore /etc/harmony-smp/tls-keystore.jks -storepass $TLSKEYPASS \
+        -keypass $TLSKEYPASS -validity 333 -keysize 3072 -dname "$SERVERDN" 2>/dev/null
 
-  TLSTRUSTSTOREPASS=$(openssl rand -base64 12)
-  keytool -export -alias selfsigned -file /etc/harmony-smp/selfsigned.cer \
-      -keystore /etc/harmony-smp/tls-keystore.jks -storepass $TLSKEYPASS 2>/dev/null
-  keytool -import -noprompt -alias selfsigned -file /etc/harmony-smp/selfsigned.cer \
-      -keystore /etc/harmony-smp/tls-truststore.jks -storepass $TLSTRUSTSTOREPASS 2>/dev/null
-  rm -f /etc/harmony-smp/selfsigned.cer
+    TLSTRUSTSTOREPASS=$(openssl rand -base64 12)
+    keytool -export -alias selfsigned -file /etc/harmony-smp/selfsigned.cer \
+        -keystore /etc/harmony-smp/tls-keystore.jks -storepass $TLSKEYPASS 2>/dev/null
+    keytool -import -noprompt -alias selfsigned -file /etc/harmony-smp/selfsigned.cer \
+        -keystore /etc/harmony-smp/tls-truststore.jks -storepass $TLSTRUSTSTOREPASS 2>/dev/null
+    rm -f /etc/harmony-smp/selfsigned.cer
 
-  E_TLSKEYPASS=$(escape_for_sed "$TLSKEYPASS")
-  E_TLSTRUSTSTOREPASS=$(escape_for_sed "$TLSTRUSTSTOREPASS")
-  sed -e "s/{{tls_keystore_password}}/$E_TLSKEYPASS/" -e "s/{{tls_truststore_password}}/$E_TLSTRUSTSTOREPASS/" \
-      /opt/harmony-smp/setup/server.xml.template > /etc/harmony-smp/tomcat-conf/server.xml
+    E_TLSKEYPASS=$(escape_for_sed "$TLSKEYPASS")
+    E_TLSTRUSTSTOREPASS=$(escape_for_sed "$TLSTRUSTSTOREPASS")
+    sed -e "s/{{tls_keystore_password}}/$E_TLSKEYPASS/" -e "s/{{tls_truststore_password}}/$E_TLSTRUSTSTOREPASS/" \
+        /opt/harmony-smp/setup/server.xml.template > /etc/harmony-smp/tomcat-conf/server.xml
 
-  sed -e "s/{{tls_truststore_password}}/$E_TLSTRUSTSTOREPASS/" \
-      /opt/harmony-smp/setup/setenv.sh.template > /opt/harmony-smp/bin/setenv.sh
+    sed -e "s/{{tls_truststore_password}}/$E_TLSTRUSTSTOREPASS/" \
+        /opt/harmony-smp/setup/setenv.sh.template > /opt/harmony-smp/bin/setenv.sh
 
-  E_DBUSER=$(escape_for_sed "$DBUSER")
-  E_DBPASSWORD=$(escape_for_sed "$DBPASSWORD")
-  sed -e "s/{{dbuser}}/$E_DBUSER/" \
-      -e "s/{{dbpassword}}/$E_DBPASSWORD/" \
-    /opt/harmony-smp/setup/context.xml.template > /etc/harmony-smp/tomcat-conf/context.xml
+    E_DBUSER=$(escape_for_sed "$DBUSER")
+    E_DBPASSWORD=$(escape_for_sed "$DBPASSWORD")
+    sed -e "s/{{dbuser}}/$E_DBUSER/" \
+        -e "s/{{dbpassword}}/$E_DBPASSWORD/" \
+        /opt/harmony-smp/setup/context.xml.template > /etc/harmony-smp/tomcat-conf/context.xml
+  fi
 
-  adduser --system --quiet --no-create-home --shell /usr/sbin/nologin --group --gecos "Harmony user" harmony-smp
+  # Required to support upgrade from 1.0.0 to 1.1.0
+  if [ ! -f /opt/harmony-smp/bin/setenv.sh ]; then
+    echo "Create /opt/harmony-smp/bin/setenv.sh file" >&2
+    cp /opt/harmony-smp/setup/setenv.sh /opt/harmony-smp/bin/setenv.sh
+  fi
+
+  # Make sure the administrative user exists
+  if ! getent passwd harmony-smp > /dev/null; then
+    adduser --system --quiet --no-create-home --shell /usr/sbin/nologin --group --gecos "Harmony user" harmony-smp
+  fi
 
   # check validity of user and group
   if [ "`id -u harmony-smp`" -eq 0 ]; then
-      echo "The Harmony SMP system user 'harmony-smp' must not have uid 0 (root).Please fix this and reinstall this package." >&2
-      exit 1
+    echo "The Harmony SMP system user 'harmony-smp' must not have uid 0 (root).Please fix this and reinstall this package." >&2
+    exit 1
   fi
   if [ "`id -g harmony-smp`" -eq 0 ]; then
-      echo "The Harmony SMP system user 'harmony-smp' must not have root as primary group. Please fix this and reinstall this package." >&2
-      exit 1
+    echo "The Harmony SMP system user 'harmony-smp' must not have root as primary group. Please fix this and reinstall this package." >&2
+    exit 1
   fi
 
   mkdir -p /opt/harmony-smp/temp


### PR DESCRIPTION
Add SMP support for version upgrades using `apt upgrade`:

- Skip all DB operations if schema already exists.
- Create keystores only if `/etc/harmony-smp/tomcat-conf/server.xml` doesn't exist yet.
- Add check that the administrative user exists.
- Recreate `/opt/harmony-smp/bin/setenv.sh` after upgrade from version 1.0.0 to 1.x.x.
- Add upgrade instructions to SMP installation guide.

JIRA: https://jira.niis.org/browse/NEDS-25