### PR TITLE
Update harmony-ap_installation_guide.md

### DIFF
--- a/doc/harmony-ap_installation_guide.md
+++ b/doc/harmony-ap_installation_guide.md
@@ -189,7 +189,8 @@ sudo systemctl enable harmony-ap
 Ensure that the `harmony-ap` service is in the `running` state (example output follows):
   ```bash
   sudo systemctl list-units "harmony-ap*"
-
+  ```
+  ```bash
   UNIT                           LOAD   ACTIVE SUB     DESCRIPTION
   harmony-ap.service             loaded active running Harmony eDelivery Access - Access Point
   ```


### PR DESCRIPTION
In section 2.7, the command and the output were in the same block, resulting in copying them both from the copy button.