### PR TITLE
NEDS-86/NEDS-87 Configure AP and SMP HTTPS port during installation

### DIFF
--- a/doc/harmony-ap_installation_guide.md
+++ b/doc/harmony-ap_installation_guide.md
@@ -13,7 +13,7 @@ Doc. ID: IG-AP
  07.01.2022 | 1.1     | Add reference to the Static Discovery Configuration Guide \[UG-SDCG\]   | Petteri Kivimäki
  08.01.2022 | 1.2     | Add party name to section [2.5](#25-access-point-installation) and TLS truststore to section [2.10](#210-location-of-configuration-and-generated-passwords) | Petteri Kivimäki
  04.02.2022 | 1.3     | Add upgrade instructions. Add section about log files                   | Petteri Kivimäki
- 23.04.2022 | 1.4     | Add port number to the Access Point Installation section                | Petteri Kivimäki
+ 23.04.2022 | 1.4     | Add port number to the Access Point Installation section. Update package repository URL. | Petteri Kivimäki
 
 ## License <!-- omit in toc -->
 
@@ -141,7 +141,7 @@ The repository key details:
 
 Add Harmony eDelivery Access package repository:
 ```bash
-sudo apt-add-repository -y "deb https://artifactory.niis.org/harmony-release-deb $(lsb_release -sc)-current main"
+sudo apt-add-repository -y "deb https://artifactory.niis.org/artifactory/harmony-release-deb $(lsb_release -sc)-current main"
 ```
 
 Update package repository metadata:

--- a/doc/harmony-ap_installation_guide.md
+++ b/doc/harmony-ap_installation_guide.md
@@ -1,6 +1,6 @@
 # Harmony eDelivery Access - Access Point Installation Guide <!-- omit in toc -->
 
-Version: 1.3  
+Version: 1.4  
 Doc. ID: IG-AP
 
 ---
@@ -13,7 +13,8 @@ Doc. ID: IG-AP
  07.01.2022 | 1.1     | Add reference to the Static Discovery Configuration Guide \[UG-SDCG\]   | Petteri Kivimäki
  08.01.2022 | 1.2     | Add party name to section [2.5](#25-access-point-installation) and TLS truststore to section [2.10](#210-location-of-configuration-and-generated-passwords) | Petteri Kivimäki
  04.02.2022 | 1.3     | Add upgrade instructions. Add section about log files                   | Petteri Kivimäki
- 
+ 23.04.2022 | 1.4     | Add port number to the Access Point Installation section                | Petteri Kivimäki
+
 ## License <!-- omit in toc -->
 
 This document is licensed under the Creative Commons Attribution-ShareAlike 4.0 International License.
@@ -93,13 +94,15 @@ The table below lists the required connections between different components.
 Out | Access Point | Data Exchange Partner Access Point | 443, 8443, other | tcp | |
 Out | Access Point | SMP | 443, 8443, other | tcp | |
 Out | Access Point | Backend (push) | 80, 443, other | tcp | Target in the internal network |
-In  | Data Exchange Partner Access Point | Access Point | 8443 | tcp | URL path: `/services/msh` |
-In | Backend (submit, pull) | Access Point | 8443 | tcp | Source in the internal network<br /><br />URL path: `/services/backend` |
-In | Admin | Access Point | 8443 | tcp | Source in the internal network<br /><br />URL path: `/` |
+In  | Data Exchange Partner Access Point | Access Point | 8443* | tcp | URL path: `/services/msh` |
+In | Backend (submit, pull) | Access Point | 8443* | tcp | Source in the internal network<br /><br />URL path: `/services/backend` |
+In | Admin | Access Point | 8443* | tcp | Source in the internal network<br /><br />URL path: `/` |
+
+\* The port number for inbound connections is configurable and the value can be set during the Access Point installation process. Port `8443` is used by default.
 
 It is strongly recommended to protect the Access Point from unwanted access using a firewall (hardware or software based). The firewall can be applied to both incoming and outgoing connections depending on the security requirements of the environment where the Access Point is deployed. It is recommended to allow incoming traffic to specific ports only from explicitly defined sources using IP filtering. **Special attention should be paid with the firewall configuration since incorrect configuration may leave the Access Point vulnerable to exploits and attacks.**
 
-In addition, it's strongly recommended to use URL path filtering for the Access Point since the admin UI, backend interface and AS4 interface all run on port `8443`.
+In addition, it's strongly recommended to use URL path filtering for the Access Point since the admin UI, backend interface and AS4 interface all run on port `8443` by default. However, the port number is configurable.
 
 **Port** | **URL Path** | **Description** |
 ---------|----------|-----------------|
@@ -164,11 +167,13 @@ Upon the first installation of the Access Point, the system asks for the followi
 - party name of the Access Point owner organisation;
   - if you don't know the party name of the owner, use the default value (`selfsigned`);
 - `Distinguished Name` for generated self-signed content and transport certificates;
-  - For example:
+  - for example:
       ```bash
       CN=example.com, O=My Organisation, C=FI
       ```
-  - *Note:* different eDelivery policy domains may have different requirements for the `Distinguished Name`. If you're not sure about the requirements, please contact the domain authority of the policy domain where the Access Point is registered.
+  - *note:* different eDelivery policy domains may have different requirements for the `Distinguished Name`. If you're not sure about the requirements, please contact the domain authority of the policy domain where the Access Point is registered;
+- port number that the Access Point listens to. The default is `8443`;
+  - the Access Point admin UI, backend interface and AS4 interface all run on the defined port.
 
 See the Static Discovery Configuration Guide \[[UG-SDCG](static_discovery_configuration_guide.md)\] and the Dynamic Discovery Configuration Guide \[[UG-DDCG](dynamic_discovery_configuration_guide.md)\] for more information about how to configure different discovery options.
 

--- a/doc/harmony-ap_installation_guide.md
+++ b/doc/harmony-ap_installation_guide.md
@@ -102,7 +102,7 @@ In | Admin | Access Point | 8443* | tcp | Source in the internal network<br /><b
 
 It is strongly recommended to protect the Access Point from unwanted access using a firewall (hardware or software based). The firewall can be applied to both incoming and outgoing connections depending on the security requirements of the environment where the Access Point is deployed. It is recommended to allow incoming traffic to specific ports only from explicitly defined sources using IP filtering. **Special attention should be paid with the firewall configuration since incorrect configuration may leave the Access Point vulnerable to exploits and attacks.**
 
-In addition, it's strongly recommended to use URL path filtering for the Access Point since the admin UI, backend interface and AS4 interface all run on port `8443` by default. However, the port number is configurable.
+In addition, it's strongly recommended to use URL path filtering for the Access Point since the admin UI, backend interface and AS4 interface all run on the same port. By default, the port number is `8443`, but it is configurable.
 
 **Port** | **URL Path** | **Description** |
 ---------|----------|-----------------|

--- a/doc/harmony-ap_installation_guide.md
+++ b/doc/harmony-ap_installation_guide.md
@@ -13,7 +13,7 @@ Doc. ID: IG-AP
  07.01.2022 | 1.1     | Add reference to the Static Discovery Configuration Guide \[UG-SDCG\]   | Petteri Kivimäki
  08.01.2022 | 1.2     | Add party name to section [2.5](#25-access-point-installation) and TLS truststore to section [2.10](#210-location-of-configuration-and-generated-passwords) | Petteri Kivimäki
  04.02.2022 | 1.3     | Add upgrade instructions. Add section about log files                   | Petteri Kivimäki
- 23.04.2022 | 1.4     | Add port number to the Access Point Installation section. Update package repository URL. | Petteri Kivimäki
+ 23.04.2022 | 1.4     | Add port number to the Access Point Installation section. Update package repository URL | Petteri Kivimäki
 
 ## License <!-- omit in toc -->
 

--- a/doc/harmony-smp_installation_guide.md
+++ b/doc/harmony-smp_installation_guide.md
@@ -15,7 +15,7 @@ Doc. ID: IG-SMP
  07.01.2021 | 1.3     | Add language types to code blocks                               | Petteri Kivimäki
  22.01.2021 | 1.4     | Add more information about keystores and trustores. Add information about properties stored in database | Petteri Kivimäki
  06.02.2021 | 1.5     | Add upgrade instructions. Add section about log files           | Petteri Kivimäki
- 23.04.2022 | 1.6     | Add port number to the SMP Installation section                 | Petteri Kivimäki
+ 23.04.2022 | 1.6     | Add port number to the SMP Installation section. Update package repository URL | Petteri Kivimäki
  
 ## License <!-- omit in toc -->
 
@@ -155,7 +155,7 @@ The repository key details:
 
 Add Harmony eDelivery Access package repository:
 ```bash
-sudo apt-add-repository -y "deb https://artifactory.niis.org/harmony-release-deb $(lsb_release -sc)-current main"
+sudo apt-add-repository -y "deb https://artifactory.niis.org/artifactory/harmony-release-deb $(lsb_release -sc)-current main"
 ```
 
 Update package repository metadata:

--- a/doc/harmony-smp_installation_guide.md
+++ b/doc/harmony-smp_installation_guide.md
@@ -1,6 +1,6 @@
 # Harmony eDelivery Access - Service Metadata Publisher Installation Guide <!-- omit in toc -->
 
-Version: 1.5  
+Version: 1.6
 Doc. ID: IG-SMP
 
 ---
@@ -15,6 +15,7 @@ Doc. ID: IG-SMP
  07.01.2021 | 1.3     | Add language types to code blocks                               | Petteri Kivimäki
  22.01.2021 | 1.4     | Add more information about keystores and trustores. Add information about properties stored in database | Petteri Kivimäki
  06.02.2021 | 1.5     | Add upgrade instructions. Add section about log files           | Petteri Kivimäki
+ 23.04.2022 | 1.6     | Add port number to the SMP Installation section                 | Petteri Kivimäki
  
 ## License <!-- omit in toc -->
 
@@ -91,12 +92,14 @@ The table below lists the required connections between different components.
 **Connection Type** | **Source** | **Target** | **Target Ports** | **Protocol** | **Note** |
 -----------|------------|-----------|-----------|-----------|-----------|
 Out | SMP | SML | 443, 8443, other | tcp | |
-In  | Data Exchange Partner Access Point | SMP | 8443 | tcp | URL paths: `/{participantIdentifier}` and `/{participantIdentifier}/services/{documentIdentifier}` |
-In | Admin | SMP | 8443 | tcp | Source in the internal network<br /><br />URL paths: `/` and `/ui` |
+In  | Data Exchange Partner Access Point | SMP | 8443* | tcp | URL paths: `/{participantIdentifier}` and `/{participantIdentifier}/services/{documentIdentifier}` |
+In | Admin | SMP | 8443* | tcp | Source in the internal network<br /><br />URL paths: `/` and `/ui` |
+
+\* The port number for inbound connections is configurable and the value can be set during the SMP installation process. Port `8443` is used by default.
 
 It is strongly recommended to protect the SMP from unwanted access using a firewall (hardware or software based). The firewall can be applied to both incoming and outgoing connections depending on the security requirements of the environment where the SMP is deployed. It is recommended to allow incoming traffic to specific ports only from explicitly defined sources using IP filtering. **Special attention should be paid with the firewall configuration since incorrect configuration may leave the SMP vulnerable to exploits and attacks.**
 
-In addition, it's strongly recommended to use URL path filtering for the SMP since the admin UI and metadata query interface run on port `8443`.
+In addition, it's strongly recommended to use URL path filtering for the SMP since the admin UI and metadata query interface run on the same port. By default, the port number is `8443`, but it is configurable.
 
 **Port** | **URL Path** | **Description** |
 ---------|----------|-----------------|
@@ -170,11 +173,13 @@ sudo apt install harmony-smp
 Upon the first installation of the SMP, the system asks for the following information.
 
 - `Distinguished Name` for generated self-signed content and transport certificates;
-  - For example:
+  - for example:
       ```bash
       CN=example.com, O=My Organisation, C=FI
       ```
-  - *Note:* different eDelivery policy domains may have different requirements for the `Distinguished Name`. If you're not sure about the requirements, please contact the domain authority of the policy domain where the SMP is registered.
+  - *note:* different eDelivery policy domains may have different requirements for the `Distinguished Name`. If you're not sure about the requirements, please contact the domain authority of the policy domain where the SMP is registered.
+- port number that the SMP listens to. The default is `8443`;
+  - the SMP admin UI and metadata query interface run on the defined port;
 - do you want the SMP installation to publish information to some Service Metadata Locator (SML);  
   - if yes then: 
     - full URL of the SML server, including protocol and port, e.g., `https://<HOST>:8443`;

--- a/packaging/common/ap/server.xml.template
+++ b/packaging/common/ap/server.xml.template
@@ -81,7 +81,7 @@
     <Connector
                SSLEnabled="true"
                protocol="org.apache.coyote.http11.Http11NioProtocol"
-               port="8443"
+               port="{{tomcat_port}}"
                maxThreads="200"
                scheme="https"
                secure="true"

--- a/packaging/common/smp/server.xml.template
+++ b/packaging/common/smp/server.xml.template
@@ -80,7 +80,7 @@
     -->
     <Connector SSLEnabled="true"
                protocol="org.apache.coyote.http11.Http11NioProtocol"
-               port="8443" maxThreads="200"
+               port="{{tomcat_port}}" maxThreads="200"
                scheme="https" secure="true"
                keystoreFile="/etc/harmony-smp/tls-keystore.jks"
                keystorePass="{{tls_keystore_password}}"

--- a/packaging/ubuntu/generic/harmony-ap.config
+++ b/packaging/ubuntu/generic/harmony-ap.config
@@ -19,6 +19,7 @@ if [ "$1" = "configure" ] || [ "$1" = "reconfigure" ]; then
   db_input high harmony-ap/adminpassword || true
   db_input high harmony-ap/partyname || true
   db_input high harmony-ap/serverdn || true
+  db_input high harmony-ap/tomcatport || true
   db_endblock
   db_go
 fi

--- a/packaging/ubuntu/generic/harmony-ap.postinst
+++ b/packaging/ubuntu/generic/harmony-ap.postinst
@@ -39,6 +39,8 @@ case "$1" in
   PARTYNAME="$RET"
   db_get harmony-ap/serverdn
   SERVERDN="$RET"
+  db_get harmony-ap/tomcatport
+  TOMCATPORT="$RET"
   db_stop
 
   DBUSER=harmony_ap
@@ -98,8 +100,10 @@ case "$1" in
     E_TLSTRUSTSTOREPASS=$(escape_for_sed "$TLSTRUSTSTOREPASS")
     E_SMLZONE=$(escape_for_sed "$SMLZONE")
     E_PARTYNAME=$(escape_for_sed "$PARTYNAME")
+    E_TOMCATPORT=$(escape_for_sed "$TOMCATPORT")
 
     sed -e "s/{{tls_keystore_password}}/$E_TLSKEYPASS/" -e "s/{{tls_truststore_password}}/$E_TLSTRUSTSTOREPASS/" \
+      -e "s/{{tomcat_port}}/$E_TOMCATPORT/" \
         /opt/harmony-ap/setup/server.xml.template > /etc/harmony-ap/tomcat-conf/server.xml
 
     sed -e "s/{{tls_truststore_password}}/$E_TLSTRUSTSTOREPASS/" \
@@ -113,6 +117,13 @@ case "$1" in
 
     sed -e "s/{{tls_truststore_password}}/$E_TLSTRUSTSTOREPASS/" \
         /opt/harmony-ap/setup/setenv.sh.template > /opt/harmony-ap/bin/setenv.sh
+
+    # Check if Tomcat runs on a privileged port - port number below 1024
+    PORT_NUMBER_REGEX='^((6553[0-5])|(655[0-2][0-9])|(65[0-4][0-9]{2})|(6[0-4][0-9]{3})|([1-5][0-9]{4})|([0-5]{0,5})|([0-9]{1,4}))$'
+    if [[ $E_TOMCATPORT =~ $PORT_NUMBER_REGEX && $E_TOMCATPORT -lt 1024 ]]; then
+        echo "Tomcat will run on a privileged port" >&2
+        setcap cap_net_bind_service+ep /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
+    fi
   fi
 
   # Required to support upgrade from 1.0.0 to 1.1.0

--- a/packaging/ubuntu/generic/harmony-ap.templates
+++ b/packaging/ubuntu/generic/harmony-ap.templates
@@ -24,3 +24,8 @@ Template: harmony-ap/partyname
 Type: string
 Default: selfsigned
 Description: Harmony Access Point owner Party Name
+
+Template: harmony-ap/tomcatport
+Type: string
+Default: 8443
+Description: Harmony Access Point port number

--- a/packaging/ubuntu/generic/harmony-smp.config
+++ b/packaging/ubuntu/generic/harmony-smp.config
@@ -4,6 +4,7 @@
 
 if [ "$1" = "configure" ] || [ "$1" = "reconfigure" ]; then
   db_input high harmony-smp/serverdn
+  db_input high harmony-smp/tomcatport
   db_input high harmony-smp/integratewithsml
   db_go
 

--- a/packaging/ubuntu/generic/harmony-smp.postinst
+++ b/packaging/ubuntu/generic/harmony-smp.postinst
@@ -37,6 +37,8 @@ case "$1" in
   SMPURL="$RET"
   db_get harmony-smp/smpip
   SMPIP="$RET"
+  db_get harmony-smp/tomcatport
+  TOMCATPORT="$RET"
 
   DBUSER=harmony_smp
   DBPASSWORD=$(openssl rand -base64 12)
@@ -133,7 +135,9 @@ case "$1" in
 
     E_TLSKEYPASS=$(escape_for_sed "$TLSKEYPASS")
     E_TLSTRUSTSTOREPASS=$(escape_for_sed "$TLSTRUSTSTOREPASS")
+    E_TOMCATPORT=$(escape_for_sed "$TOMCATPORT")
     sed -e "s/{{tls_keystore_password}}/$E_TLSKEYPASS/" -e "s/{{tls_truststore_password}}/$E_TLSTRUSTSTOREPASS/" \
+        -e "s/{{tomcat_port}}/$E_TOMCATPORT/" \
         /opt/harmony-smp/setup/server.xml.template > /etc/harmony-smp/tomcat-conf/server.xml
 
     sed -e "s/{{tls_truststore_password}}/$E_TLSTRUSTSTOREPASS/" \
@@ -144,6 +148,13 @@ case "$1" in
     sed -e "s/{{dbuser}}/$E_DBUSER/" \
         -e "s/{{dbpassword}}/$E_DBPASSWORD/" \
         /opt/harmony-smp/setup/context.xml.template > /etc/harmony-smp/tomcat-conf/context.xml
+
+    # Check if Tomcat runs on a privileged port - port number below 1024
+    PORT_NUMBER_REGEX='^((6553[0-5])|(655[0-2][0-9])|(65[0-4][0-9]{2})|(6[0-4][0-9]{3})|([1-5][0-9]{4})|([0-5]{0,5})|([0-9]{1,4}))$'
+    if [[ $E_TOMCATPORT =~ $PORT_NUMBER_REGEX && $E_TOMCATPORT -lt 1024 ]]; then
+        echo "Tomcat will run on a privileged port" >&2
+        setcap cap_net_bind_service+ep /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
+    fi
   fi
 
   # Required to support upgrade from 1.0.0 to 1.1.0

--- a/packaging/ubuntu/generic/harmony-smp.templates
+++ b/packaging/ubuntu/generic/harmony-smp.templates
@@ -18,12 +18,17 @@ Description: IP address of this SMP server
 Template: harmony-smp/adminuser
 Type: string
 Default: harmony
-Description: Harmony Accesspoint administator user name
+Description: Administator username of this SMP server
 
 Template: harmony-smp/adminpassword
 Type: password
-Description: Harmony Accesspoint administator initial password
+Description: Initial administator password of this SMP server
 
 Template: harmony-smp/serverdn
 Type: string
-Description: Distinguished name of generated selfsigned server certificate
+Description: Distinguished name of generated self-signed server certificate
+
+Template: harmony-smp/tomcatport
+Type: string
+Default: 8443
+Description: Port number of this SMP server


### PR DESCRIPTION
- Make Tomcat port configurable on AP ([NEDS-86](https://jira.niis.org/browse/NEDS-86))
  - Ask Tomcat port number during the installation process.
  - If the port is a privileged port, grant `harmony-ap` process permission to listen on the port.
  - Update documentation.
- Make Tomcat port configurable on SMP ([NEDS-87](https://jira.niis.org/browse/NEDS-87))
  - Ask Tomcat port number during the installation process.
  - If the port is a privileged port, grant `harmony-smp` process permission to listen on the port.
  - Update documentation.
- Update AP and SMP repository URL in user guides.